### PR TITLE
add lambda capture list

### DIFF
--- a/limo/test.hpp
+++ b/limo/test.hpp
@@ -201,10 +201,15 @@ namespace limo {
         }
     };
 
-    #define LTEST(test_name, ...) \
+    // First arg is a test name, second(optional) arg is a lambda capture list in parentheses
+    #define LTEST(...) LTEST_IMPL(__VA_ARGS__, (), )
+    #define LTEST_IMPL(test_name, capture, ...) \
         limo::Registrator ltest_ ## test_name = \
             limo::TestSettings(#test_name,  get_ltest_context()) << \
-            [__VA_ARGS__](limo::TestContextGetter& get_ltest_context) mutable -> void
+            [OPEN_PARENTHESES capture](limo::TestContextGetter& get_ltest_context) mutable -> void
+
+    // Preprocessor utils
+    #define OPEN_PARENTHESES(...) __VA_ARGS__
 
     #define LBEFORE get_ltest_context()->m_before = [&]()
     #define LAFTER  get_ltest_context()->m_after  = [&]()

--- a/limo_examples/testing/basics/test_basics.cpp
+++ b/limo_examples/testing/basics/test_basics.cpp
@@ -128,6 +128,25 @@ LTEST(my_sqare) {
 
     // auto my_sqare = [](int x) { return x * x; };
     
+    LTEST(capture) {
+        LTEST(by) {
+            auto true_sqare = [](int x) { return x * x; };
+            const int x = 3;
+
+            LTEST(list, (&true_sqare, x)) {
+                EXPECT_EQ(9, true_sqare(x));
+            };
+
+            LTEST(reference, (&)) {
+                EXPECT_EQ(9, true_sqare(x));
+            };
+
+            LTEST(value, (=)) {
+                EXPECT_EQ(9, true_sqare(x));
+            };
+        };
+    };
+
     LTEST(degenarated) {
         EXPECT_EQ(0, my_sqare(0));
     };


### PR DESCRIPTION
This is an approach to fix warning: ISO C++11 requires at least one argument for the "..." in a variadic macro