### PR TITLE
Add lambda capture all scope 

### DIFF
--- a/limo/test.hpp
+++ b/limo/test.hpp
@@ -201,10 +201,15 @@ namespace limo {
         }
     };
 
-    #define LTEST(test_name, ...) \
+    // First arg is a test name, second(optional) is a lambda capture type
+    #define LTEST(...) LTEST_IMPL(__VA_ARGS__, EMPTY, EMPTY)
+    #define LTEST_IMPL(test_name, capture, ...) \
         limo::Registrator ltest_ ## test_name = \
             limo::TestSettings(#test_name,  get_ltest_context()) << \
-            [__VA_ARGS__](limo::TestContextGetter& get_ltest_context) mutable -> void
+            [capture](limo::TestContextGetter& get_ltest_context) mutable -> void
+
+    // Preprocessor utils
+    #define EMPTY
 
     #define LBEFORE get_ltest_context()->m_before = [&]()
     #define LAFTER  get_ltest_context()->m_after  = [&]()

--- a/limo_examples/testing/basics/test_basics.cpp
+++ b/limo_examples/testing/basics/test_basics.cpp
@@ -128,6 +128,20 @@ LTEST(my_sqare) {
 
     // auto my_sqare = [](int x) { return x * x; };
     
+    LTEST(capture) {
+        LTEST(by) {
+            auto true_sqare = [](int x) { return x * x; };
+
+            LTEST(reference, &) {
+                EXPECT_EQ(9, true_sqare(3));
+            };
+
+            LTEST(value, =) {
+                EXPECT_EQ(9, true_sqare(3));
+            };
+        };
+    };
+
     LTEST(degenarated) {
         EXPECT_EQ(0, my_sqare(0));
     };


### PR DESCRIPTION
This is the another approach ([first here](https://github.com/ddolzhenko/limo/pull/3)) to fix warning: ISO C++11 requires at least one argument for the "..." in a variadic macro

But in contrast to the first approach it allows to capture only all scope by reference or value. 